### PR TITLE
Control simtk lib import

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,6 @@ Changelog
 * corrected argparse autodoc in ReadTheDocs (mock strategy)
 * improved tox configuration with better env separation
 * #19 reports a communication error between TravisCI and coverage servers
->>>>>>> master
 
 0.8.2 (2020-01-17)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,11 @@ Upon version 0.8, and before version 1, SV2 major version increments are reflect
 Changelog
 =========
 
+0.8.3 (2020-xx-xx)
+------------------
+
+* Added simtk import control and error message output
+
 0.8.2 (2020-01-17)
 ------------------
 

--- a/tests/test_libmdt.py
+++ b/tests/test_libmdt.py
@@ -1,5 +1,6 @@
 """Test libmdt."""
 import mdtraj as md
+import pytest
 
 from taurenmd.libs import libmdt
 
@@ -18,3 +19,21 @@ def test_load_traj_cif():
     traj = libmdt.load_traj(toptest_cif, trajtest)
     assert isinstance(traj, md.Trajectory)
     assert len(traj) == 10
+
+
+def test_load_traj_cif_import_error():
+    """Test loading traj."""
+    libmdt.SIMTK = False
+    with pytest.raises(SystemExit) as err:
+        libmdt.load_traj(toptest_cif, trajtest)
+    assert err.type == SystemExit
+    assert err.value.code == 0
+
+
+def test_simtk_import_error():
+    """Test import error message."""
+    with pytest.raises(SystemExit) as err:
+        libmdt._log_simtkimport_error()
+    
+    assert err.type == SystemExit
+    assert err.value.code == 0


### PR DESCRIPTION
* OpenMM is only used for loading `.cif` files as topologies and for MDTraj
* Added import control statement and error message to enhance user directed messages
* This avoids Anaconda dependencies if users do not want to use this feature.
* added respective tests

