### PR TITLE
Improved Tox env isolation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ matrix:
       env:
         - TOXENV=docs
     - env:
-        - TOXENV=clean,py36,codecov,coveralls,report
+        - TOXENV=clean,py36,codecov,coveralls
       python: '3.6'
     - env:
-        - TOXENV=clean,py37,codecov,coveralls,report
+        - TOXENV=clean,py37,codecov,coveralls
       python: '3.7'
 
 before_install:

--- a/tests/test_libcli.py
+++ b/tests/test_libcli.py
@@ -26,7 +26,7 @@ def test_maincli():
     parser.add_argument('--cov', nargs=argparse.REMAINDER)
     result = lc.maincli(parser, myfunc)
     # since we have it, lets play it with and close the circle
-    assert result == '--cov-report=term-missing --cov-append -vv tests'.split()
+    assert result == '--cov-report=term-missing -vv tests'.split()
 
 
 def test_save_refs():

--- a/tests/test_libcli.py
+++ b/tests/test_libcli.py
@@ -26,7 +26,7 @@ def test_maincli():
     parser.add_argument('--cov', nargs=argparse.REMAINDER)
     result = lc.maincli(parser, myfunc)
     # since we have it, lets play it with and close the circle
-    assert result == '--cov-report=term-missing -vv tests'.split()
+    assert result == '--cov-report=term-missing --cov-append -vv tests'.split()
 
 
 def test_save_refs():

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,5 @@
 [tox]
 minversion = 3.14.0
-#requires = 
-#    setuptools >= 45.0.0
-#    tox-conda >= 0.2
 envlist =
     clean
     check
@@ -10,38 +7,26 @@ envlist =
     docs
     py36
     py37
-    report
+#report
 ignore_basepython_conflict = true
 
 [testenv]
 basepython =
     {py36}: {env:TOXPYTHON:python3.6}
     {py37,docs}: {env:TOXPYTHON:python3.7}
-    {clean,check,radon,report,codecov,coveralls}: {env:TOXPYTHON:python3}
+    {clean,check,radon,codecov,coveralls}: {env:TOXPYTHON:python3}
+passenv = *
+
+[testenv:py36]
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
-    COV_CORE_SOURCE={toxinidir}/src
-    COV_CORE_CONFIG={toxinidir}/.coveragerc
-    COV_CORE_DATAFILE={toxinidir}/.coverage.eager
-passenv =
-    *
-
-[testenv:py36]
-#usedevelop = false
-#commands_pre = python setup.py develop --no-deps
-#skip_install = true
-#setenv =
-#    PYTHONPATH={toxinidir}/tests
-#    PYTHONUNBUFFERED=yes
-#passenv =
-#    *
-user_develop = true
+user_develop = false
 deps =
     pytest
     pytest-travis-fold
     pytest-cov
-#converage
+    coverage
     bioplottemplates
     pyquaternion
 conda_deps =
@@ -54,14 +39,19 @@ conda_channels =
     omnia
     defaults
 commands =
-    {posargs:pytest --cov --cov-report=term-missing --cov-append -vv tests}
+    {posargs:pytest --cov --cov-report=term-missing -vv tests}
+commands_post = 
+    coverage report
+    coverage html
 
 [testenv:py37]
-user_develop = true
+setenv = {[testenv:py36]setenv}
+user_develop = {[testenv:py36]user_develop}
 deps = {[testenv:py36]deps}
 conda_deps = {[testenv:py36]conda_deps}
 conda_channels = {[testenv:py36]conda_channels}
 commands = {[testenv:py36]commands}
+commands_post = {[testenv:py36]commands_post}
 
 [testenv:check]
 deps =
@@ -117,13 +107,12 @@ skip_install = true
 commands =
     coveralls []
 
-[testenv:report]
-deps = coverage
-skip_install = true
-commands =
-#coverage combine --append
-    coverage html
-    coverage report
+#[testenv:report]
+#deps = coverage
+#skip_install = true
+#commands =
+#    coverage report
+#    coverage html
 
 [testenv:clean]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,8 @@
 [tox]
+minversion = 3.14.0
+#requires = 
+#    setuptools >= 45.0.0
+#    tox-conda >= 0.2
 envlist =
     clean,
     check,
@@ -13,11 +17,13 @@ basepython =
     {py36}: {env:TOXPYTHON:python3.6}
     {py37,docs}: {env:TOXPYTHON:python3.7}
     {clean,check,radon,report,codecov,coveralls}: {env:TOXPYTHON:python3}
+passenv =
+    *
+
+[testenv:py37]
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
-passenv =
-    *
 usedevelop = false
 deps =
     pytest
@@ -74,6 +80,7 @@ commands =
     #sphinx-build -b linkcheck docs dist/docs
 
 [testenv:codecov]
+depends = report
 deps =
     codecov
 skip_install = true
@@ -81,6 +88,7 @@ commands =
     codecov []
 
 [testenv:coveralls]
+depends = report
 deps =
     coveralls
 skip_install = true
@@ -88,6 +96,7 @@ commands =
     coveralls []
 
 [testenv:report]
+depends = py36,py37
 deps = coverage
 skip_install = true
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,12 @@ minversion = 3.14.0
 #    setuptools >= 45.0.0
 #    tox-conda >= 0.2
 envlist =
-    clean,
-    check,
-    radon,
-    docs,
-    {py36,py37}-test,
+    clean
+    check
+    radon
+    docs
+    py36
+    py37
     report
 ignore_basepython_conflict = true
 
@@ -23,7 +24,7 @@ setenv =
 passenv =
     *
 
-[testenv:test]
+[testenv:py36]
 #usedevelop = false
 #commands_pre = python setup.py develop --no-deps
 #skip_install = true
@@ -46,8 +47,14 @@ conda_channels =
 commands =
     {posargs:pytest --cov --cov-report=term-missing -vv tests}
 
+[testenv:py37]
+user_develop = true
+deps = {[testenv:py36]deps}
+conda_deps = {[testenv:py36]conda_deps}
+conda_channels = {[testenv:py36]conda_channels}
+commands = {[testenv:py36]commands}
+
 [testenv:check]
-basepython = python3.7
 deps =
     docutils
     check-manifest
@@ -102,7 +109,6 @@ commands =
     coveralls []
 
 [testenv:report]
-depends = py36,py37
 deps = coverage
 skip_install = true
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
     check,
     radon,
     docs,
-    {py36,py37},
+    {py36,py37}-test,
     report
 ignore_basepython_conflict = true
 
@@ -17,14 +17,17 @@ basepython =
     {py36}: {env:TOXPYTHON:python3.6}
     {py37,docs}: {env:TOXPYTHON:python3.7}
     {clean,check,radon,report,codecov,coveralls}: {env:TOXPYTHON:python3}
-passenv =
-    *
-
-[testenv:py37]
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
-usedevelop = false
+passenv =
+    *
+
+[testenv:test]
+#usedevelop = false
+#commands_pre = python setup.py develop --no-deps
+#skip_install = true
+user_develop = true
 deps =
     pytest
     pytest-travis-fold
@@ -44,6 +47,7 @@ commands =
     {posargs:pytest --cov --cov-report=term-missing -vv tests}
 
 [testenv:check]
+basepython = python3.7
 deps =
     docutils
     check-manifest
@@ -54,6 +58,7 @@ deps =
     pygments
     isort
     bumpversion
+#usedevelop = false
 skip_install = true
 commands =
     python setup.py check --strict --metadata --restructuredtext
@@ -73,6 +78,7 @@ commands =
 
 [testenv:docs]
 usedevelop = true
+#skip_install = true
 deps =
     -r{toxinidir}/docs/requirements.txt
 commands =
@@ -136,7 +142,14 @@ sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 #known_future_library=future,pies
 #known_standard_library=std,std2
 known_first_party = taurenmd
-known_third_party = pytest,bioplottemplates,pyquaternion
+known_third_party = 
+    bioplottemplates
+    MDAnalysis
+    mdtraj
+    numpy
+    simtk
+    pyquaternion
+    pytest
 
 [tool:pytest]
 # If a pytest section is found in one of the possible config files

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,9 @@ basepython =
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
+    COV_CORE_SOURCE={toxinidir}/src
+    COV_CORE_CONFIG={toxinidir}/.coveragerc
+    COV_CORE_DATAFILE={toxinidir}/.coverage.eager
 passenv =
     *
 
@@ -28,11 +31,17 @@ passenv =
 #usedevelop = false
 #commands_pre = python setup.py develop --no-deps
 #skip_install = true
+#setenv =
+#    PYTHONPATH={toxinidir}/tests
+#    PYTHONUNBUFFERED=yes
+#passenv =
+#    *
 user_develop = true
 deps =
     pytest
     pytest-travis-fold
     pytest-cov
+#converage
     bioplottemplates
     pyquaternion
 conda_deps =
@@ -45,7 +54,7 @@ conda_channels =
     omnia
     defaults
 commands =
-    {posargs:pytest --cov --cov-report=term-missing -vv tests}
+    {posargs:pytest --cov --cov-report=term-missing --cov-append -vv tests}
 
 [testenv:py37]
 user_develop = true
@@ -112,13 +121,14 @@ commands =
 deps = coverage
 skip_install = true
 commands =
-    coverage report
+#coverage combine --append
     coverage html
+    coverage report
 
 [testenv:clean]
-commands = coverage erase
 skip_install = true
 deps = coverage
+commands = coverage erase
 
 
 # my favourite configuration for flake8 styling


### PR DESCRIPTION
Improved `tox` env isolation:
* only `py36` and `py37` install runtime dependencies
* other `envs` act only on the src files and do not perform installation nor deps installation
* `docs` env now matches (hopefully) the ReaTheDocs build env, related with #16 mock configuration and does not use `tox` installed `taurenmd` dependencies.