### PR TITLE
Improve Tox configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ matrix:
       env:
         - TOXENV=docs
     - env:
-        - TOXENV=clean,py36,codecov,coveralls,report
+        - TOXENV=py36,codecov,coveralls
       python: '3.6'
     - env:
-        - TOXENV=clean,py37,codecov,coveralls,report
+        - TOXENV=py37,codecov,coveralls
       python: '3.7'
 
 before_install:

--- a/tests/test_libcli.py
+++ b/tests/test_libcli.py
@@ -26,7 +26,10 @@ def test_maincli():
     parser.add_argument('--cov', nargs=argparse.REMAINDER)
     result = lc.maincli(parser, myfunc)
     # since we have it, lets play it with and close the circle
-    assert result == '--cov-report=term-missing -vv tests'.split()
+    assert result == (
+        '--cov-report=term-missing '
+        '--cov-append --cov-config=.coveragerc -vv tests'
+        ).split()
 
 
 def test_save_refs():

--- a/tests/test_libplot.py
+++ b/tests/test_libplot.py
@@ -1,0 +1,28 @@
+"""Test libplot."""
+
+from taurenmd import Path
+from taurenmd.libs import libplot as lplt
+
+
+def test_param():
+    """Test param plot."""
+    p = Path('param.pdf')
+    lplt.param(
+        list(range(10)),
+        list(range(10)),
+        filename='param.pdf',
+        )
+    assert p.exists()
+    p.unlink()
+
+
+def test_label_dots():
+    """Test label_dots plot."""
+    p = Path('label_dots.pdf')
+    lplt.param(
+        ['a', 'b', 'c'],
+        list(range(3)),
+        filename='label_dots.pdf',
+        )
+    assert p.exists()
+    p.unlink()

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ ignore_basepython_conflict = true
 basepython =
     {py36}: {env:TOXPYTHON:python3.6}
     {py37,docs}: {env:TOXPYTHON:python3.7}
-    {clean,check,radon,codecov,coveralls}: {env:TOXPYTHON:python3}
+    {check,radon,codecov,coveralls}: {env:TOXPYTHON:python3}
 passenv = *
 
 [testenv:py36]
@@ -120,10 +120,10 @@ commands =
 #    coverage report
 #    coverage html
 
-[testenv:clean]
-skip_install = true
-deps = coverage
-commands = coverage erase
+#[testenv:clean]
+#skip_install = true
+#deps = coverage
+#commands = coverage erase
 
 
 # my favourite configuration for flake8 styling

--- a/tox.ini
+++ b/tox.ini
@@ -1,28 +1,35 @@
 [tox]
+minversion = 3.14.0
 envlist =
-    clean,
-    check,
-    radon,
-    docs,
-    {py36,py37},
-    report
+    clean
+    check
+    radon
+    docs
+    py36
+    py37
+#report
 ignore_basepython_conflict = true
 
 [testenv]
 basepython =
     {py36}: {env:TOXPYTHON:python3.6}
     {py37,docs}: {env:TOXPYTHON:python3.7}
-    {clean,check,radon,report,codecov,coveralls}: {env:TOXPYTHON:python3}
+    {clean,check,radon,codecov,coveralls}: {env:TOXPYTHON:python3}
+passenv = *
+
+[testenv:py36]
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
-passenv =
-    *
-usedevelop = false
+#COV_CORE_SOURCE=
+#COV_CORE_CONFIG={toxinidir}/.coveragerc
+#COV_CORE_DATAFILE={toxinidir}/.coverage
+user_develop = false
 deps =
     pytest
     pytest-travis-fold
     pytest-cov
+    coverage
     bioplottemplates
     pyquaternion
 conda_deps =
@@ -34,8 +41,23 @@ conda_channels =
     conda-forge
     omnia
     defaults
+commands_pre =
+    coverage erase
 commands =
-    {posargs:pytest --cov --cov-report=term-missing -vv tests}
+    {posargs:pytest --cov --cov-report=term-missing --cov-append --cov-config=.coveragerc -vv tests}
+commands_post = 
+    coverage report
+    coverage html
+
+[testenv:py37]
+setenv = {[testenv:py36]setenv}
+user_develop = {[testenv:py36]user_develop}
+deps = {[testenv:py36]deps}
+conda_deps = {[testenv:py36]conda_deps}
+conda_channels = {[testenv:py36]conda_channels}
+commands_pre = {[testenv:py36]commands_pre}
+commands = {[testenv:py36]commands}
+commands_post = {[testenv:py36]commands_post}
 
 [testenv:check]
 deps =
@@ -48,6 +70,7 @@ deps =
     pygments
     isort
     bumpversion
+#usedevelop = false
 skip_install = true
 commands =
     python setup.py check --strict --metadata --restructuredtext
@@ -67,6 +90,7 @@ commands =
 
 [testenv:docs]
 usedevelop = true
+#skip_install = true
 deps =
     -r{toxinidir}/docs/requirements.txt
 commands =
@@ -74,6 +98,7 @@ commands =
     #sphinx-build -b linkcheck docs dist/docs
 
 [testenv:codecov]
+depends = report
 deps =
     codecov
 skip_install = true
@@ -81,23 +106,24 @@ commands =
     codecov []
 
 [testenv:coveralls]
+depends = report
 deps =
     coveralls
 skip_install = true
 commands =
     coveralls []
 
-[testenv:report]
-deps = coverage
-skip_install = true
-commands =
-    coverage report
-    coverage html
+#[testenv:report]
+#deps = coverage
+#skip_install = true
+#commands =
+#    coverage report
+#    coverage html
 
 [testenv:clean]
-commands = coverage erase
 skip_install = true
 deps = coverage
+commands = coverage erase
 
 
 # my favourite configuration for flake8 styling
@@ -127,26 +153,33 @@ sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 #known_future_library=future,pies
 #known_standard_library=std,std2
 known_first_party = taurenmd
-known_third_party = pytest,bioplottemplates,pyquaternion
+known_third_party = 
+    bioplottemplates
+    MDAnalysis
+    mdtraj
+    numpy
+    simtk
+    pyquaternion
+    pytest
 
 [tool:pytest]
 # If a pytest section is found in one of the possible config files
 # (pytest.ini, tox.ini or setup.cfg), then pytest will not look for any others,
 # so if you add a pytest config section elsewhere,
 # you will need to delete this section from setup.cfg.
-norecursedirs =
-    migrations
-
+#norecursedirs =
+#migrations
+addopts = -p pytest_cov
 python_files =
     test_*.py
     *_test.py
     tests.py
-addopts =
-    -ra
-    --strict
-    --doctest-modules
-    --doctest-glob=\*.rst
-    --tb=short
+#addopts =
+#    -ra
+#    --strict
+#    --doctest-modules
+#    --doctest-glob=\*.rst
+#    --tb=short
 testpaths =
     tests
 


### PR DESCRIPTION
Improved `tox` env isolation:
* only `py36` and `py37` install runtime dependencies
* other `envs` act only on the src files and do not perform installation nor deps installation
* `docs` env now matches (hopefully) the ReaTheDocs build env, related with #16 mock configuration and does not use `tox` installed `taurenmd` dependencies.

During this process I faced a problem with `coverage report` results. With the `tox` config previous to this PR the coverage was reporting correctly, but with the separation of `testenv` from `py36` coverage results diverge and decorator lines are registered as uncovered, but only in online repositories, locally coverage reports properly. I ended up removing the clean and report envs and add those as `command_pre` and `command_post` options, I found this to solve the solution locally.

I did try as much as I could solutions, may be in a future PR this can be solved. For know I am closing it, because improvements in tox env management really pay off.

Useful links for future reference:
* https://coverage.readthedocs.io/en/coverage-5.0.3/faq.html
* https://pytest-cov.readthedocs.io/en/latest/plugins.html
* https://github.com/pytest-dev/pytest-cov/issues/301
* https://github.com/pytest-dev/pytest-cov/issues/177
* https://github.com/pytest-dev/pytest-cov/issues/117

I think the problem is that reflected in the first link, but I do not see why this configuration does not solve the problem, SPECIALLY, because the problem happens during the transfer from Travis-CI and coverage servers, locally and on travis-ci logs everything looks good. I am too puzzled.

This PR is a repeat from #18 because I though coverage reports there (in coverage servers) were getting contaminated from previous commits.