### PR TITLE
pip package deps

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,14 @@ Upon version 0.8, and before version 1, SV2 major version increments are reflect
 Changelog
 =========
 
+0.x.x (2020-xx-xx)
+------------------
+
+* organized dependencies for PyPI
+* PyPI only dependencies are referred as install_requires
+* MDAnalysis and MDTraj referred in extras_require
+* OpenMM left out from pip, only available in Anaconda
+
 0.8.4 (2020-01-19)
 ------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
 requires = [
-    "setuptools>=30.3.0",
+    "setuptools>=45",
     "wheel",
 ]

--- a/setup.py
+++ b/setup.py
@@ -28,12 +28,14 @@ from os.path import basename, dirname, join, splitext
 from setuptools import find_packages, setup
 
 
-if not os.getenv('READTHEDOCS'):
-    install_requires = [
-        'bioplottemplates',
-        'pyquaternion',
-        ]
-else:
+install_requires = [
+    'matplotlib>=3,<4',
+    'numpy>=1,<2',
+    'bioplottemplates>0.1',
+    'pyquaternion',
+    ]
+
+if os.getenv('READTHEDOCS'):
     install_requires = []
 
 
@@ -98,14 +100,9 @@ setup(
     install_requires=install_requires,
     extras_require={
         'all': [
-            'matplotlib>=3,<4',
-            'numpy>=1,<2',
             'MDAnalysis>=0.2,<1',
             'mdtraj>=1,<2',
             ]
-        # eg:
-        #   'rst': ['docutils>=0.11'],
-        #   ':python_version=="2.6"': ['argparse'],
         },
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -86,8 +86,12 @@ setup(
         ],
     python_requires='>=3.6, <3.8',
     install_requires=[
+        'matplotlib>=3, <4',
+        'numpy',
         'bioplottemplates',
         'pyquaternion',
+        'MDAnalysis',
+        'mdtraj',
         ],
     extras_require={
         # eg:

--- a/setup.py
+++ b/setup.py
@@ -86,14 +86,20 @@ setup(
         ],
     python_requires='>=3.6, <3.8',
     install_requires=[
-        'matplotlib>=3, <4',
-        'numpy',
+        #'matplotlib>=3, <4',
+        #'numpy',
         'bioplottemplates',
         'pyquaternion',
-        'MDAnalysis',
-        'mdtraj',
+        #'MDAnalysis',
+        #'mdtraj',
         ],
     extras_require={
+        'all': [
+            'matplotlib>=3, <4',
+            'numpy',
+            'MDAnalysis',
+            'mdtraj',
+            ]
         # eg:
         #   'rst': ['docutils>=0.11'],
         #   ':python_version=="2.6"': ['argparse'],


### PR DESCRIPTION
* Structures `taurenmd` pip package dependencies.
* pip hosted dependencies are stated as `install requires`
* Molecular Dynamics analysis packages, also hosted on Anaconda, are referred as `extras_require` and are available through `pip install --upgrade taurenmd[all]`
* `OpenMM` package is not consider because is only available in conda omnia channel.