### PR TITLE
restructured pip dependencies hierarchy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,12 @@ Upon version 0.8, and before version 1, SV2 major version increments are reflect
 Changelog
 =========
 
+0.8.x (2020-01-xx)
+------------------
+
+* Restructured pip deps: install_requires only takes bioplottemplates and pyquaternion
+* two extras_require: `sup` and `md` and `all` which consider both
+
 0.8.5 (2020-01-20)
 ------------------
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -11,6 +11,3 @@ dependencies:
     - openmm
     - matplotlib=3
     - numpy=1
-    - pip:
-        - bioplottemplates
-        - pyquaternion

--- a/setup.py
+++ b/setup.py
@@ -29,14 +29,26 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    'matplotlib>=3,<4',
-    'numpy>=1,<2',
     'bioplottemplates>0.1',
     'pyquaternion',
     ]
 
 if os.getenv('READTHEDOCS'):
     install_requires = []
+
+# support deps
+supdeps = [
+    'matplotlib>=3,<4',
+    'numpy>=1,<2',
+    ]
+
+# Molecular Dynamics deps
+mddeps = [
+    'MDAnalysis>=0.2,<1',
+    'mdtraj>=1,<2',
+    ]
+
+alldeps = mddeps + supdeps
 
 
 def _read(*names, **kwargs):
@@ -99,10 +111,9 @@ setup(
     python_requires='>=3.6, <3.8',
     install_requires=install_requires,
     extras_require={
-        'all': [
-            'MDAnalysis>=0.2,<1',
-            'mdtraj>=1,<2',
-            ]
+        'all': alldeps,
+        'md': mddeps,
+        'sup': supdeps,
         },
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
After #22,

restructured pip dependencies hierarchy. The default `taurenmd` installation assumes Molecular Dynamics libraries are already install: `pip install taurenmd`, instead if the install is from scratch `pip install taurenmd[all]`. 

* `install_requires` considers only `bioplottemplates` and `pyquaternion`.
* created 3 `extra_requires`: `all`, `sup` and `md`