### PR TITLE
Corrected command representation with quotes

### DIFF
--- a/src/taurenmd/libs/libcli.py
+++ b/src/taurenmd/libs/libcli.py
@@ -150,9 +150,22 @@ def save_command(fname, *args):
         fh.write(
             '[{}] {}\n'.format(
                 datetime.now().strftime("%d/%m/%Y, %H:%M:%S"),
-                ' '.join(str(a) for a in args),
+                ' '.join(represent_argument(a) for a in args),
                 )
             )
+
+
+def represent_argument(arg):
+    """
+    Represent argument in a string.
+
+    If argument has spaces represents string with quotation marks ".
+    """
+    sarg = str(arg)
+    if sarg.count(' ') > 0:
+        return '{!r}'.format(sarg)
+    else:
+        return sarg
 
 
 def add_subparser(parser, module):

--- a/tests/test_libcli.py
+++ b/tests/test_libcli.py
@@ -474,3 +474,17 @@ def test_data_export_arg(cmd, expected):
     lc.add_data_export_arg(parser)
     v = vars(parser.parse_args(cmd.split()))
     assert v['export'] == expected
+
+
+@pytest.mark.parametrize(
+    'arg,expected',
+    [
+        (1, '1'),
+        ('-a', '-a'),
+        ('segid A or resnum 10', "'segid A or resnum 10'"),
+        ]
+    )
+def test_represent_argument(arg, expected):
+    """Test argument representation."""
+    result = lc.represent_argument(arg)
+    assert result == expected


### PR DESCRIPTION
Command representation in `.taurenmd.cmd` was not representing argument strings with spaces with the needed quotation marks:

**previous behaviour:**

saved in `.taurenmd.cmd`

```bash
taurenmd trajedit topology.pdb trajectory.xtc -d output.xtc -a (segid D or resnum 11-19) or (segid E or resnum 12-20)
```

**current behaviour:**

```bash
taurenmd trajedit topology.pdb trajectory.xtc -d output.xtc -a '(segid D or resnum 11-19) or (segid E or resnum 12-20)'
```

this allows the command to be copy+pasted directly to bash.

**proposed version increment:** patch