### PR TITLE
Install taurenmd from pip directly in Anaconda requirements.yml

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -80,8 +80,8 @@ We do not provide support for other distribution platforms such as `HomeBrew <ht
 
 **User installation suggestions for particular systems:**
 
-#. `pyenv in Arch Linux <https://github.com/joaomcteixeira/taurenmd/issues/34>`_
-#. `on zsh <https://github.com/joaomcteixeira/taurenmd/issues/35>`_
+#. :issue:`pyenv in Arch Linux <34>`
+#. :issue:`on zsh <35>`
 
 
 From GitHub

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -47,10 +47,13 @@ Where ``taurenmdenv.yml`` is the file downloaded in the previous step.
 
     conda activate taurenmd
 
-4. Install *taurenmd* itself::
+4. You are ready, type::
 
-    pip install taurenmd
-    
+    taurenmd
+
+to start using ``taurenmd``.
+
+
 With PyPI
 `````````
 
@@ -63,16 +66,22 @@ If you do not use `Anaconda`_ and you actually rely on `PyPI`_ as your package m
     python -m pip install --upgrade pip wheel
     pip3 install taurenmd[all]
 
-3. What is the problem with the pure PyPI installation?
+3. You should be good to go
 
-*taurenmd* relies on OpenMM to read ``.cif`` topology files, and OpenMM is not deployed on PyPI, you need to `install it through its conda channel <https://anaconda.org/omnia/openmm>`_. Therefore, unless you need to load ``.cif`` files you can use *taurenmd* from a pure PyPI installation. Otherwise, you should follow the :ref:`With Anaconda` instructions. :ref:`May be you want to help us out solving this problem :-) <Contributing>`.
+Note. What is the problem with the pure PyPI installation?
 
-4. You should be good to go
+*taurenmd* relies on OpenMM to read ``.cif`` topology files when using routines based on ``MDTraj``, and OpenMM is not deployed on PyPI and requires `installation through its conda channel <https://anaconda.org/omnia/openmm>`_. Therefore, unless you need to load ``.cif`` files you can use *taurenmd* from a pure PyPI installation. Otherwise, you should follow the :ref:`With Anaconda` instructions. :ref:`May be you want to help us out solving this problem :-) <Contributing>`.
+
 
 Other Platforms
 ```````````````
 
 We do not provide support for other distribution platforms such as `HomeBrew <https://brew.sh/>`_ or `Chocolatey <https://chocolatey.org/>`_, but may be you can emulate the steps described above for these systems. Feel welcomed to :ref:`improve this documentation with your insights <Contributing>`!
+
+**User installation suggestions for particular systems:**
+
+#. `pyenv in Arch Linux <https://github.com/joaomcteixeira/taurenmd/issues/34>`_
+#. `on zsh <https://github.com/joaomcteixeira/taurenmd/issues/35>`_
 
 
 From GitHub

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,10 +4,12 @@ channels:
     - omnia
     - defaults
 dependencies:
-    - pip
     - python=3.7
     - mdanalysis
     - mdtraj
     - openmm
     - matplotlib=3
     - numpy=1
+    - pip
+    - pip:
+        - taurenmd


### PR DESCRIPTION
* Adds `pip` install of `taurenmd` directly in Anaconda `requirements.yml` file. Comes after the suggestion in #36.
* updates documentation 
* adds installation suggestion from #34 and #35 
* Closes #35 

Version update suggestion: `patch`.