### PR TITLE
Removed build badge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
-name: build
+# this action must be synchronized with version-bump-and-package.yml
+name: test_build
 
 on:
   pull_request:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ Upon version 0.8, and before version 1, SV2 major version increments are reflect
 Changelog
 =========
 
+* Remove README badge for build: not needed.
+* Added some comments in the workflow files.
+* no changes in code, only CI.
+
 v0.9.5 (2021-02-17)
 ------------------------------------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -17,13 +17,9 @@ taurenmd
     :target: https://doi.org/10.5281/zenodo.3551990
     :alt: Zenodo
 
-.. image:: https://github.com/joaomcteixeira/taurenmd/workflows/test_py37/badge.svg?branch=master
+.. image:: https://github.com/joaomcteixeira/taurenmd/workflows/Tests/badge.svg?branch=master
     :target: https://github.com/joaomcteixeira/taurenmd/actions?workflow=test_py37
     :alt: Test Status
-
-.. image:: https://github.com/joaomcteixeira/taurenmd/workflows/build/badge.svg?branch=master
-    :target: https://github.com/joaomcteixeira/taurenmd/actions?workflow=build
-    :alt: Package Build
 
 .. image:: https://img.shields.io/readthedocs/taurenmd/latest?label=Read%20the%20Docs
     :target: https://taurenmd.readthedocs.io/en/latest/index.html


### PR DESCRIPTION
- Build badge unnecessary because we already have the PyPI.
- Added some comments in the workflow files.